### PR TITLE
(CVM) Fix Springboot CVM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,8 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.2.3</version>
+		<version>3.2.3</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
Upgrade spring-boot-start-parent library version from 3.1.5 to 3.2.3